### PR TITLE
Display a consistent placeholder document title

### DIFF
--- a/client/components/OrganizationDocument/OrganizationDocument.js
+++ b/client/components/OrganizationDocument/OrganizationDocument.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { generateDocumentTitle } from 'utilities';
 import { ProgressBar } from '@blueprintjs/core';
 
 require('./organizationDocument.scss');
@@ -9,12 +10,12 @@ const propTypes = {
 };
 
 const OrganizationDocument = function(props) {
-	const name = props.documentData.title || props.documentData.fileName || props.documentData.name;
+	const generatedTitle = generateDocumentTitle(props.documentData);
 	const url = props.documentData.id ? `/doc/${props.documentData.id}` : props.documentData.url;
 	return (
 		<li className="organization-document-component">
-			{url && <a href={url}>{name}</a>}
-			{!url && <div>{name}</div>}
+			{url && <a href={url}>{generatedTitle.title}</a>}
+			{!url && <div>{generatedTitle.title}</div>}
 			{!url && (
 				<ProgressBar
 					value={props.documentData.progress === 1 ? null : props.documentData.progress}

--- a/client/components/SearchResult/SearchResult.js
+++ b/client/components/SearchResult/SearchResult.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import dateFormat from 'dateformat';
+import { generateDocumentTitle } from 'utilities';
 
 require('./searchResult.scss');
 
@@ -14,8 +15,6 @@ const defaultProps = {
 	isLoading: false,
 };
 
-const defaultTitle = 'Untitled';
-
 const SearchResult = function(props) {
 	if (props.isLoading) {
 		return (
@@ -27,7 +26,7 @@ const SearchResult = function(props) {
 		);
 	}
 
-	const title = props.data.title || '';
+	const generatedTitle = generateDocumentTitle(props.data.title);
 	const copyright = props.data.copyright || '';
 	const highlight = props.data.highlight || null;
 	const cpcCodes = props.data.cpcCodes || [];
@@ -49,12 +48,10 @@ const SearchResult = function(props) {
 	const fileUrl = props.data.fileUrl;
 	const documentUrl = props.data.id ? `/doc/${props.data.id}` : fileUrl;
 
-	const titleClass = title ? 'title' : 'untitled';
-	const titleText = title || defaultTitle;
 	return (
 		<div className="search-result-wrapper">
-			<div className={titleClass}>
-				<a href={documentUrl}>{titleText}</a>
+			<div className={`title ${generatedTitle.isPlaceholder ? 'placeholder' : ''}`}>
+				<a href={documentUrl}>{generatedTitle.title}</a>
 			</div>
 			{fileUrl && (
 				<a href={fileUrl} className="url">

--- a/client/components/SearchResult/searchResult.scss
+++ b/client/components/SearchResult/searchResult.scss
@@ -8,16 +8,15 @@
 	.title {
 		font-size: 1.2em;
 		font-weight: 600;
-	}
-	.untitled {
-		font-size: 1.2em;
-		font-weight: initial;
-		font-style: italic;
-		a {
-			color: grey;
+		&.placeholder {
+			font-size: 1.2em;
+			font-weight: initial;
+			font-style: italic;
+			a {
+				color: grey;
+			}
 		}
 	}
-
 	.url {
 		margin: 0px 0px;
 		color: #1e9f40;

--- a/client/containers/Document/Document.js
+++ b/client/containers/Document/Document.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PageWrapper from 'components/PageWrapper/PageWrapper';
-import { hydrateWrapper } from 'utilities';
+import { hydrateWrapper, generateDocumentTitle } from 'utilities';
 import { HTMLTable } from '@blueprintjs/core';
 
 require('./document.scss');
@@ -13,7 +13,6 @@ const propTypes = {
 	assertionData: PropTypes.array.isRequired,
 };
 
-const placeholderTitle = 'Untitled Document';
 const placeholderDescription = 'No description available.';
 
 const gatewayUrl = 'https://dev-gateway.underlay.store/ipfs/';
@@ -36,6 +35,7 @@ const Document = function(props) {
 	const updatedAt = formatDate(props.documentData.updatedAt);
 	const publicationDate = formatDate(props.documentData.publicationDate);
 	const cpcCodes = props.documentData.cpcCodes || [];
+	const generatedTitle = generateDocumentTitle(title);
 	return (
 		<div id="document-container">
 			<PageWrapper loginData={props.loginData} locationData={props.locationData}>
@@ -43,8 +43,8 @@ const Document = function(props) {
 					<div id="flex-container" className="row">
 						<div className="col-12">
 							<header>
-								<h1 className={title ? '' : 'placeholder'}>
-									{title || placeholderTitle}
+								<h1 className={generatedTitle.isPlaceholder ? 'placeholder' : ''}>
+									{generatedTitle.title}
 								</h1>
 								<section className={description ? '' : 'placeholder'}>
 									{description || placeholderDescription}

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -211,3 +211,23 @@ export function s3Upload(
 	getPolicy.open('GET', `/api/uploadPolicy?contentType=${file.type}&hasMeta=${hasMeta}`);
 	getPolicy.send();
 }
+
+export function generateDocumentTitle(stub) {
+	const placeholderTitle = 'Untitled Document';
+	const generatedTitle = {
+		title: placeholderTitle,
+	};
+	if (stub) {
+		if (typeof stub === 'object') {
+			// This needs formalizing and improving. It was plucked from OrganizationDocument.
+			const tryTitle = stub.title || stub.fileName || stub.name;
+			if (tryTitle) {
+				generatedTitle.title = tryTitle;
+			}
+		} else {
+			generatedTitle.title = stub;
+		}
+	}
+	generatedTitle.isPlaceholder = generatedTitle.title === placeholderTitle;
+	return generatedTitle;
+}


### PR DESCRIPTION
Documents without titles display some a placeholder title in various views. Before, this wasn’t centrally stored or generated, so each view (search results, organization profile, document page) generated their own slightly different placeholder title.

Now we generate them centrally with a utility function. However, this needs to be improved and formalized and maybe not even defined as a utility function.

Affects prior-art-archive/overview#29