### PR TITLE
Generate sitemaps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -259,6 +259,19 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/node": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.2.2.tgz",
+      "integrity": "sha512-jPqgTycE26uFsuWpLika9Ohz9dmLQHWjOnMNxBOjYb1HXO+eLKxEr5FfKSXH/tBvFwwaw+pzke3gagnurGOfCA==",
+      "dev": true,
+      "requires": {
+        "@babel/polyfill": "^7.0.0",
+        "@babel/register": "^7.0.0",
+        "commander": "^2.8.1",
+        "lodash": "^4.17.10",
+        "v8flags": "^3.1.1"
+      }
+    },
     "@babel/parser": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.0.tgz",
@@ -673,6 +686,30 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0",
         "regexpu-core": "^4.1.3"
+      }
+    },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-env": {
@@ -11847,6 +11884,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
       "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
+    },
+    "v8flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
+      "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prod": "npm run build-prod && npm run api-prod",
     "lint": "eslint .",
     "start": "concurrently --kill-others \"npm run api-dev\" \"npm run build-dev\"",
+    "generate-sitemap": "NODE_PATH=./client babel-node ./scripts/sitemapRunner",
     "storybook": "start-storybook -p 9001 -c .storybook -s ./"
   },
   "dependencies": {
@@ -104,6 +105,7 @@
     "node": "10.14.1"
   },
   "devDependencies": {
+    "@babel/node": "^7.2.2",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-prettier": "^3.0.1",
     "prettier": "^1.16.4"

--- a/scripts/sitemapRunner.js
+++ b/scripts/sitemapRunner.js
@@ -1,0 +1,4 @@
+import sitemapWorker from '../workers/sitemap'
+
+sitemapWorker.run()
+.then(() => process.exit())

--- a/server/clientRoutes/cpc.js
+++ b/server/clientRoutes/cpc.js
@@ -1,0 +1,6 @@
+import app from '../server';
+
+app.get('/cpc/sitemap', (req, res)=> {
+  const sitemapPrefix = process.env.SITEMAP_PREFIX || '';
+  request(`https://s3.amazonaws.com/prior-art-archive-sftp/_priorArtArchive/{$sitemapPrefix}sitemap.txt`).pipe(res);
+});

--- a/server/config.sample.js
+++ b/server/config.sample.js
@@ -5,3 +5,8 @@ process.env.DATABASE_URL = '<YOUR-POSTGRES-URI>';
 process.env.AWS_ACCESS_KEY_ID = '<ACCESS-KEY>';
 process.env.AWS_SECRET_ACCESS_KEY = '<SECRET-KEY>';
 process.env.MAILGUN_API_KEY = '<MAILGUN_API_KEY>';
+
+// The s3 location that the site map should be compiled to
+// Leave blank to skip sitemap generation
+process.env.SITEMAP_DESTINATION_S3_BUCKET = ''
+process.env.SITEMAP_DESTINATION_PATH = ''

--- a/workers/sitemap/awsUpload.js
+++ b/workers/sitemap/awsUpload.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import Promise from 'bluebird';
+import AWS from 'aws-sdk';
+
+const fsReadFile = Promise.promisify(fs.readFile);
+
+function getS3Bucket() {
+	return new AWS.S3({
+		params: {
+			Bucket: process.env.SITEMAP_DESTINATION_S3_BUCKET
+		}
+	});
+}
+
+function getS3Params(data) {
+	return {
+		Key: process.env.SITEMAP_DESTINATION_PATH,
+		Body: data,
+		ACL: 'public-read',
+	}
+}
+
+async function putDataInS3(data) {
+	AWS.config.region = process.env.AWS_REGION;
+	AWS.config.setPromisesDependency(Promise);
+	const s3bucket = getS3Bucket();
+	const params = getS3Params(data);
+	return s3bucket.putObject(params).promise();
+}
+
+async function uploadSiteMap(filePath) {
+	const data = await fsReadFile(filePath)
+	return putDataInS3(data)
+}
+
+module.exports = {
+	uploadSiteMap
+}

--- a/workers/sitemap/index.js
+++ b/workers/sitemap/index.js
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import tmp from 'tmp-promise';
+import Promise from 'bluebird';
+import { Document, Organization } from '../../server/models';
+import { uploadSiteMap } from './awsUpload';
+
+const fsWriteFile = Promise.promisify(fs.writeFile);
+
+async function getDocuments() {
+	return Document.findAll({});
+}
+
+function generateSitemapData(documents) {
+	const byDateUploaded = (a, b) => {
+		if (a.dateUploaded > b.dateUploaded) return -1;
+		if (a.dateUploaded < b.dateUploaded) return 1;
+		return 0;
+	}
+
+	return documents.map((document)=> {
+		return {
+			url: document.fileUrl,
+			fileId: document.id,
+			companyName: '',
+			companyId: document.organizationId,
+			title: document.title,
+			dateUploaded: '',
+			datePublished: document.publicationDate,
+			sourcePath: '',
+		};
+	}).sort(byDateUploaded);
+}
+
+async function createTmpFile() {
+	tmp.setGracefulCleanup();
+	return tmp.file({
+		postfix: '.txt',
+	})
+}
+
+function packageSitemapContent(sitemapData) {
+	return sitemapData.reduce((prev, curr)=> {
+		return `${prev}${JSON.stringify(curr)}\n`;
+	}, '')
+}
+
+async function writeSitemap(filePath, content) {
+	return fsWriteFile(filePath, content, 'utf-8')
+}
+
+async function run() {
+	const documents = await getDocuments()
+	const tmpFile = await createTmpFile()
+	const sitemapData = generateSitemapData(documents)
+	const sitemapContent = packageSitemapContent(sitemapData)
+	await writeSitemap(tmpFile.path, sitemapContent)
+	console.log('Succesfully generated new sitemap');
+	await uploadSiteMap(tmpFile.path)
+	return;
+}
+
+module.exports = {
+	run
+}


### PR DESCRIPTION
This PR generates sitemaps, which is the first part of the CPC process (issue #10 )

## Changes

Some key changes from the way this works in v1:

1. Instead of using promises this uses async functions, which makes for more readable code.
2. Some of the fields (`sourcePath` and `dateUploaded`) don't seem to be represented any longer in the model.
3. I forgot to re-implement company title lookup whoops; doing that now but review anyway please.
4. AWS locations are now driven by config files.


## New Config

Two new lines need to be added to your config file:

* `process.env.SITEMAP_DESTINATION_S3_BUCKET = ''`
* `process.env.SITEMAP_DESTINATION_PATH = ''`

The first is the s3 bucket (e.g. `prior-art-archive-sftp`)
The second is the path within the s3 bucket (e.g. `_priorArtArchive/sitemap_dev.txt`)

This PR also sneaks in an editor config file, which should be its own PR but don't tell anybody and they might not notice.